### PR TITLE
Move TF graph building to preparation

### DIFF
--- a/lin_regression/graphtensorflow.py
+++ b/lin_regression/graphtensorflow.py
@@ -17,6 +17,7 @@ class GraphTensorFlow(Gen):
         grad = f * tf.matmul(tf.transpose(self.X_tf), e)
 
         self.training_op = tf.assign(w, w - self.mu * grad)
+        
         init = tf.global_variables_initializer()
         self.sess.run(init)
         self.sess.run(self.training_op)

--- a/lin_regression/graphtensorflow.py
+++ b/lin_regression/graphtensorflow.py
@@ -11,19 +11,22 @@ class GraphTensorFlow(Gen):
         f = 2 / self.N
 
         w = tf.Variable(tf.zeros((2, 1)), name="w_tf")
+        self.w = w
         y = tf.matmul(self.X_tf, w, name="y_tf")
         e = y - self.d_tf
         grad = f * tf.matmul(tf.transpose(self.X_tf), e)
 
-        training_op = tf.assign(w, w - self.mu * grad)
+        self.training_op = tf.assign(w, w - self.mu * grad)
         init = tf.global_variables_initializer()
         self.sess.run(init)
+        self.sess.run(self.training_op)
 
 
     def run(self):
         for epoch in range(self.N_epochs):
-            self.sess.run(training_op)
-        opt = w.eval()
+            self.sess.run(self.training_op)
+        opt = self.sess.run(self.w)
+        self.sess.close()
         return opt.squeeze()
 
 

--- a/lin_regression/graphtensorflow.py
+++ b/lin_regression/graphtensorflow.py
@@ -6,8 +6,8 @@ class GraphTensorFlow(Gen):
     def prepare(self):
         self.X_tf = tf.constant(self.X, dtype=tf.float32, name="X_tf")
         self.d_tf = tf.constant(self.d[:,None], dtype=tf.float32, name="d_tf")
-
-    def run(self):
+        self.sess = tf.Session()
+        
         f = 2 / self.N
 
         w = tf.Variable(tf.zeros((2, 1)), name="w_tf")
@@ -17,12 +17,13 @@ class GraphTensorFlow(Gen):
 
         training_op = tf.assign(w, w - self.mu * grad)
         init = tf.global_variables_initializer()
+        self.sess.run(init)
 
-        with tf.Session() as sess:
-            init.run()
-            for epoch in range(self.N_epochs):
-                sess.run(training_op)
-            opt = w.eval()
+
+    def run(self):
+        for epoch in range(self.N_epochs):
+            self.sess.run(training_op)
+        opt = w.eval()
         return opt.squeeze()
 
 


### PR DESCRIPTION
Hi @henryiii ,
nice benchmark examples! I've came across the TF implementation (from the purepython site) that you also have and it seems that the benchmarking could be improved.

I've moved the whole graph building to the `prepare`, so that the actual calculation only is run inside `run`.
