### PR TITLE
updates nim code for equivalence to PureNumpy & C++ float32 treatments

### DIFF
--- a/lin_regression/README.md
+++ b/lin_regression/README.md
@@ -64,6 +64,6 @@ Nim example (contributed):
 
 ```
 (w0: 2.968954757075724, w1: 2.02593328759163)
-Nim time: 0.139302 seconds
+Nim time: ~~0.139302 seconds~~ (needs to be rerun using the newer code)
 ```
 

--- a/lin_regression/example.nim
+++ b/lin_regression/example.nim
@@ -12,13 +12,13 @@ randomize(444)
 
 const
   N = 10_000
-  sigma = 0.1
-  f = 2 / N
-  mu = 0.001
+  sigma = 0.1'f32
+  f = float32(2 / N)
+  mu = 0.001'f32
   nEpochs = 10_000
 
 
-proc randomNormal(mean = 0.0, std = 1.0): float =
+proc randomNormal(mean = 0.0, std = 1.0): float32 =
   # https://github.com/mratsim/Arraymancer/blob/master/src/tensor/init_cpu.nim#L209-L222
   let
     x = rand(1.0)
@@ -27,21 +27,21 @@ proc randomNormal(mean = 0.0, std = 1.0): float =
   return rho * cos(2.0 * PI * x) * std + mean
 
 
-var x, d: array[N, float]
+var x, d: array[N, float32]
 for i in 0 ..< N:
-  x[i] = f * i.float
-  d[i] = 3.0 + 2.0 * x[i] + sigma * randomNormal()
+  x[i] = f * i.float32
+  d[i] = 3.0.float32 + 2.0.float32 * x[i] + sigma * randomNormal()
 
 
-proc gradientDescent(x, d: array[N, float], mu: float, nEpochs: int):
-    tuple[w0, w1: float] =
+proc gradientDescent(x, d: array[N, float32], mu: float32, nEpochs: int):
+    tuple[w0, w1: float32] =
   var
-    y: array[N, float]
-    err: float
-    w0, w1: float
+    y: array[N, float32]
+    err: float32
+    w0, w1: float32
 
   for n in 1 .. nEpochs:
-    var grad0, grad1: float
+    var grad0, grad1: float32
 
     for i in 0 ..< N:
       err = f * (d[i] - y[i])
@@ -60,3 +60,4 @@ proc gradientDescent(x, d: array[N, float], mu: float, nEpochs: int):
 let start = cpuTime()
 echo gradientDescent(x, d, mu, nEpochs)
 echo "Nim time: ", cpuTime() - start, " seconds"
+

--- a/lin_regression/runall.sh
+++ b/lin_regression/runall.sh
@@ -20,7 +20,7 @@ pypy3 purenumpy.py
 
 echo "Nim:"
 
-nim -c -d:release example.nim
+nim c -d:release example.nim
 ./example
 
 echo "C++:"


### PR DESCRIPTION
Just a small update since this benchmark table is still public :)

From a cursory glance, at least the PureNumpy and C++ code was specifically written to use 32-bit floating point numbers. As it was written, then Nim code used 64-bit floats. Using specifically 32-bit like the C++ and PureNumpy codes do causes the benchmark time between Nim and C++ to become effectively equivalent.